### PR TITLE
Remove root requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ If you have no idea what Duckyscript is, see the [Hak5 USB Rubber Ducky Wiki](ht
 
 For practical usage instructions and gotchas, check on [the Wiki page](https://github.com/phikshun/jackit/wiki).
 
+### Running as non root
+To use jackit without root privileges, you can add an `udev` rule for the CrazyRadio PA dongle.
+Example: `/etc/udev/rules.d/41-mousejack.rules`
+```
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="0102", GROUP="plugdev", MODE="0660"
+```
+Assuming your user is in `plugdev` group, this rule will allow you to use the device. Restart the `udev` service to apply the rule.
+
 ## Who
 
 This implementation was written by phikshun and infamy. Our code is all BSD license. All the files in the lib directory were written by Bastille's research team and are GPLv3 license.

--- a/bin/jackit
+++ b/bin/jackit
@@ -112,14 +112,6 @@ def banner():
     print("")
 
 
-def confirm_root():
-    # make sure we are root
-    if os.getuid() != 0 and platform.system() != 'Darwin':
-        _print_err("ERROR: You need to run as root!")
-        _print_err("login as root (su root) or try sudo %s" % sys.argv[0])
-        exit(-1)
-
-
 @click.command()
 @click.option('--debug', is_flag=True, help='Enable debug')
 @click.option('--script', default="", help="Ducky file to use for injection", type=click.Path())
@@ -135,7 +127,6 @@ def confirm_root():
 def cli(debug, script, lowpower, interval, layout, address, vendor, reset, autopwn, all_channels, keylogging):
 
     banner()
-    confirm_root()
 
     if debug:
         print(O + "[W] " + W + "Debug is enabled.")


### PR DESCRIPTION
root is required only for the dongle access, this change remove root requirement (`confirm_root` function) and add an udev rule example in the readme to allow user to run jackit as non root